### PR TITLE
chore: drop redundant license-file from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "thesauromatic"
 version = "0.0.11"
 edition = "2018"
 license = "AGPL-3.0"
-license-file = "LICENSE"
 description = """
 thesauromatic is a command-line thesaurus that returns
 related words when given a word. The output words are


### PR DESCRIPTION
`license = "AGPL-3.0"` is a standard SPDX expression, so `license-file = "LICENSE"` is redundant. cargo warns that only one of the two is necessary; this drops the file reference and silences the warning. The `LICENSE` file itself is unaffected.